### PR TITLE
chore: Remove status field from booking schema

### DIFF
--- a/models/bookingModel.js
+++ b/models/bookingModel.js
@@ -20,11 +20,6 @@ const bookingSchema = new mongoose.Schema({
     type: Number,
     required: true,
   },
-  status: {
-    type: String,
-    default: "Pending",
-    enum: ["Pending", "Confirmed", "Cancelled"],
-  },
   created_at: {
     type: Date,
     default: Date.now,


### PR DESCRIPTION
- Removed the `status` field from the booking schema, including its default value and enum validation.
- Cleaned up unused code to streamline the schema.

This commit removes the status field from the booking schema, simplifying the data model.