### PR TITLE
test: Add unit tests for updateLocation controller

### DIFF
--- a/tests/locationTest/locationController_PUT.test.js
+++ b/tests/locationTest/locationController_PUT.test.js
@@ -1,0 +1,100 @@
+const { describe, it, expect } = require("@jest/globals");
+
+jest.mock("../../models/locationModel", () => {
+  return {
+    findByIdAndUpdate: jest.fn(),
+  };
+});
+
+const { updateLocation } = require("../../controllers/locationController");
+const Location = require("../../models/locationModel");
+
+describe("updateLocation Controller", () => {
+  it("should return a 400 error if no fields are provided to update", async () => {
+    const req = {
+      params: { id: "123" },
+      body: {},
+    };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+    await updateLocation(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(next).toHaveBeenCalledWith(
+      new Error("Please provide fields to update")
+    );
+  });
+
+  it("should return a 400 error if a required field is empty", async () => {
+    const req = {
+      params: { id: "123" },
+      body: {
+        country: "",
+      },
+    };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+    await updateLocation(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Please provide fields to update" })
+    );
+  });
+
+  it("should return a 404 error if no location is found by the given ID", async () => {
+    Location.findByIdAndUpdate.mockResolvedValue(null);
+    const req = {
+      params: { id: "123" },
+      body: {
+        country: "USA",
+      },
+    };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+    await updateLocation(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(next).toHaveBeenCalledWith(
+      new Error("There is no location by this ID")
+    );
+  });
+
+  it("should return a 200 status and updated location if the update is successful", async () => {
+    const req = {
+      params: { id: "123" },
+      body: { country: "USA", city: "New York" },
+    };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+    const updatedLocation = {
+      id: "123",
+      country: "USA",
+      city: "New York",
+      address: "123 try try try",
+      zip_code: 1231,
+      updated_at: Date.now(),
+    };
+    Location.findByIdAndUpdate.mockResolvedValue(updatedLocation);
+    updatedLocation.save = jest.fn().mockResolvedValue(updatedLocation);
+    await updateLocation(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      message: "Location updated successfully",
+      data: updatedLocation,
+    });
+  });
+
+  it("should handle unexpected errors and pass them to the next middleware", async () => {
+    const error = new Error("Unexpected error");
+    Location.findByIdAndUpdate.mockRejectedValue(error);
+    const req = {
+      params: { id: "123" },
+      body: {
+        country: "USA",
+      },
+    };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+    await updateLocation(req, res, next);
+    expect(next).toHaveBeenCalledWith(error);
+  });
+});


### PR DESCRIPTION
- Added Jest tests for the `updateLocation` controller, covering multiple scenarios:
  - Ensures a 400 error is returned when no fields are provided for update.
  - Validates handling of empty required fields with an appropriate 400 error.
  - Handles a 404 error when no location is found by the given ID.
  - Successfully updates a location when valid fields are provided, returning a 200 status and the updated location.
  - Handles unexpected errors and passes them to the next middleware.

- Mocked `Location.findByIdAndUpdate` to simulate database operations.
- Improved error handling validation and test coverage.

This commit ensures the `updateLocation` controller is robust and reliable.