### PR TITLE
test: Add unit tests for createReview controller

### DIFF
--- a/tests/reveiwTest/reviewController_POST.test.js
+++ b/tests/reveiwTest/reviewController_POST.test.js
@@ -1,0 +1,117 @@
+const { describe, it, expect } = require("@jest/globals");
+const { createReview } = require("../../controllers/reviewController");
+const Review = require("../../models/reviewModel");
+
+jest.mock("../../models/reviewModel");
+
+describe("createReview Controller", () => {
+  it("should return a 404 error if rating is missing", async () => {
+    const req = {
+      body: { description: "Great stay!", user: "User 1", hotel: "Hotel 1" },
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const next = jest.fn();
+    await createReview(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Rating is required" })
+    );
+  });
+
+  it("should return a 404 error if description is missing", async () => {
+    const req = {
+      body: { rating: 5, user: "User 1", hotel: "Hotel 1" },
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const next = jest.fn();
+    await createReview(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Description is required" })
+    );
+  });
+
+  it("should return a 404 error if user is missing", async () => {
+    const req = {
+      body: { rating: 5, description: "Great stay!", hotel: "Hotel 1" },
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const next = jest.fn();
+    await createReview(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "User is required" })
+    );
+  });
+
+  it("should return a 404 error if hotel is missing", async () => {
+    const req = {
+      body: { rating: 5, description: "Great stay!", user: "User 1" },
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const next = jest.fn();
+    await createReview(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Hotel is required" })
+    );
+  });
+
+  it("should return a 201 status and the created review if all fields are provided", async () => {
+    const mockReview = {
+      _id: "123",
+      rating: 5,
+      description: "Great stay!",
+      user: "User 1",
+      hotel: "Hotel 1",
+    };
+    Review.mockImplementation(() => ({
+      save: jest.fn().mockResolvedValue(mockReview),
+    }));
+    const req = {
+      body: mockReview,
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const next = jest.fn();
+    await createReview(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith(mockReview);
+  });
+
+  it("should handle unexpected errors and pass them to the next middleware", async () => {
+    const error = new Error("Unexpected error");
+    Review.mockImplementation(() => ({
+      save: jest.fn().mockRejectedValue(error),
+    }));
+    const req = {
+      body: {
+        rating: 5,
+        description: "Great stay!",
+        user: "User 1",
+        hotel: "Hotel 1",
+      },
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const next = jest.fn();
+    await createReview(req, res, next);
+    expect(next).toHaveBeenCalledWith(error);
+  });
+});


### PR DESCRIPTION
- Added Jest unit tests for the `createReview` controller, covering:
  - A `404` error if any required field (rating, description, user, hotel) is missing.
  - A `201` status and the created review when all fields are provided.
  - Handling unexpected errors by passing them to the next middleware.

- Mocked `Review.save` to simulate saving the review to the database.
- Ensured tests validate proper error handling and successful review creation.

This commit improves the test coverage and reliability of the `createReview` controller.