### PR TITLE
test: Add unit tests for getRoom controller

### DIFF
--- a/tests/roomTest/roomController_GET_BY_ID.test.js
+++ b/tests/roomTest/roomController_GET_BY_ID.test.js
@@ -1,0 +1,67 @@
+const { describe, it, expect } = require("@jest/globals");
+const { getRoom } = require("../../controllers/roomController");
+const Room = require("../../models/roomModel");
+
+jest.mock("../../models/roomModel");
+
+describe("getRoom Controller", () => {
+  it("should return a 404 error if no room is found by the given ID", async () => {
+    Room.findById.mockImplementation(() => ({
+      populate: jest.fn().mockReturnThis(),
+      exec: jest.fn().mockResolvedValue(null),
+    }));
+    const req = {
+      params: { id: "123" },
+    };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+    await getRoom(req, res, next);
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 404,
+        message: "There are no room available",
+      })
+    );
+  });
+
+  it("should return a 200 status and the room if found", async () => {
+    const mockRoom = [
+      {
+        _id: "123",
+        room_type: "Single",
+        room_number: 101,
+        price: 100,
+        status: "Available",
+        hotel: 150,
+        amenities: [121, 122],
+      },
+    ];
+    Room.findById.mockImplementation(() => ({
+      populate: jest.fn().mockReturnThis(),
+      exec: jest.fn().mockResolvedValue(mockRoom),
+    }));
+    const req = {
+      params: { id: "123" },
+    };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+    await getRoom(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(mockRoom);
+  });
+
+  it("should handle unexpected errors and pass them to the next middleware", async () => {
+    const error = new Error("Unexpected error");
+    Room.findById.mockImplementation(() => ({
+      populate: jest.fn().mockReturnThis(),
+      exec: jest.fn().mockRejectedValue(error),
+    }));
+    const req = {
+      params: { id: "123" },
+    };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+    await getRoom(req, res, next);
+    expect(next).toHaveBeenCalledWith(error);
+  });
+});


### PR DESCRIPTION
- Implemented Jest tests for the `getRoom` controller, covering:
  - A `404` error when no room is found by the provided ID.
  - A `200` status and returning the room details when the room is found.
  - Handling unexpected errors by passing them to the next middleware.

- Mocked `Room.findById` with chaining for `.populate()` and `.exec()` methods to simulate database operations.

This commit enhances test coverage and verifies the proper handling of various scenarios in the `getRoom` controller.