### PR TITLE
Refactor: getAmenities endpoint: Remove population of hotel_amenities

### DIFF
--- a/controllers/amenityController.js
+++ b/controllers/amenityController.js
@@ -13,10 +13,11 @@ const Amenity = require("../models/amenity");
  */
 const getAmenities = async (req, res, next) => {
   try {
-    const amenities = await Amenity.find().populate("hotel_amenities");
-    if (!amenities) {
-      res.status(404);
-      throw new Error("There are no amenities available");
+    const amenities = await Amenity.find();
+    if (!amenities || amenities.length === 0) {
+      return res.status(404).json({
+        message: "There are no amenities available",
+      });
     }
     return res.status(200).json(amenities);
   } catch (error) {


### PR DESCRIPTION
- Removed `.populate("hotel_amenities")` from the Amenity query.
- Added check for an empty amenities array and return a 404 with a message if no amenities are found.
- Improved response format with a structured error message for better clarity.