### PR TITLE
Enhance getRooms controller with Redis caching and pagination

### DIFF
--- a/tests/roomTest/roomController_GET.test.js
+++ b/tests/roomTest/roomController_GET.test.js
@@ -1,56 +1,137 @@
-const { describe, it, expect } = require('@jest/globals');
-const { getRooms } = require('../../controllers/roomController');
-const Room = require('../../models/roomModel');
+const { describe, it, expect, afterEach } = require("@jest/globals");
+const { getRooms } = require("../../controllers/roomController");
+const Room = require("../../models/roomModel");
+const client = require("../../config/redisConfig"); // Redis client
 
-jest.mock('../../models/roomModel');
+// Mock dependencies
+jest.mock("../../models/roomModel", () => ({
+  find: jest.fn().mockReturnThis(),
+  populate: jest.fn().mockReturnThis(),
+  skip: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  exec: jest.fn(),
+  countDocuments: jest.fn(),
+}));
 
-describe('getRooms Controller', () => {
-  it('should return a 404 error if no rooms are found', async () => {
-    Room.find.mockImplementation(() => ({
-      populate: jest.fn().mockReturnThis(),
-      exec: jest.fn().mockResolvedValue([]),
-    }));
-    const req = {};
-    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
-    const next = jest.fn();
-    await getRooms(req, res, next);
-    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 404, message: 'There are no rooms available' }));
+jest.mock("../../config/redisConfig", () => ({
+  get: jest.fn(),
+  setEx: jest.fn(),
+}));
+
+// Mock pagination function
+jest.mock("../../utils/pagination", () => jest.fn((req) => ({
+  page: req.query.page || 1,
+  limit: req.query.limit || 10,
+  skip: ((req.query.page || 1) - 1) * (req.query.limit || 10),
+})));
+
+describe("getRooms Controller", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  it('should return a 200 status and the rooms if found', async () => {
-    const mockRooms = [
-      {
-        _id: '123',
-        room_type: 'Single',
-        room_number: 101,
-        price: 100,
-        status: 'Available',
-        hotel: 150,
-        amenities: [121, 122],
-      },
-    ];
-    Room.find.mockImplementation(() => ({
-      populate: jest.fn().mockReturnThis(),
-      exec: jest.fn().mockResolvedValue(mockRooms),
-    }));
-    const req = {};
-    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  it("should return cached data if available", async () => {
+    const cachedData = JSON.stringify([
+      { id: "1", hotel: "Hotel1", amenities: ["WiFi", "Pool"] },
+    ]);
+    client.get.mockResolvedValue(cachedData);
+
+    const req = { query: { page: 1, limit: 10 } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
     const next = jest.fn();
+
     await getRooms(req, res, next);
+
+    expect(client.get).toHaveBeenCalledWith("rooms:page:1:limit:10");
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith(mockRooms);
+    expect(res.json).toHaveBeenCalledWith(JSON.parse(cachedData));
+    expect(Room.find).not.toHaveBeenCalled();
   });
 
-  it('should handle unexpected errors and pass them to the next middleware', async () => {
-    const error = new Error('Unexpected error');
-    Room.find.mockImplementation(() => ({
-      populate: jest.fn().mockReturnThis(),
-      exec: jest.fn().mockRejectedValue(error),
-    }));
-    const req = {};
-    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  it("should fetch data from MongoDB and cache it when no cached data is found", async () => {
+    const mockRooms = [
+      { id: "1", hotel: "Hotel1", amenities: ["WiFi", "Pool"] },
+      { id: "2", hotel: "Hotel2", amenities: ["Gym", "Spa"] },
+    ];
+    client.get.mockResolvedValue(null);
+    Room.exec.mockResolvedValue(mockRooms);
+    Room.countDocuments.mockResolvedValue(20);
+
+    const req = { query: { page: 1, limit: 10 } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
     const next = jest.fn();
+
     await getRooms(req, res, next);
-    expect(next).toHaveBeenCalledWith(error);
+
+    expect(client.get).toHaveBeenCalledWith("rooms:page:1:limit:10");
+    expect(Room.find).toHaveBeenCalled();
+    expect(Room.populate).toHaveBeenCalledWith("hotel amenities");
+    expect(Room.skip).toHaveBeenCalledWith(0);
+    expect(Room.limit).toHaveBeenCalledWith(10);
+    expect(Room.exec).toHaveBeenCalled();
+    expect(client.setEx).toHaveBeenCalledWith(
+      "rooms:page:1:limit:10",
+      3600,
+      JSON.stringify(mockRooms)
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      page: 1,
+      limit: 10,
+      total: 20,
+      totalPage: 2,
+      data: mockRooms,
+    });
+  });
+
+  it("should return a 404 error if no rooms are found", async () => {
+    client.get.mockResolvedValue(null);
+    Room.exec.mockResolvedValue([]);
+
+    const req = { query: { page: 1, limit: 10 } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const next = jest.fn();
+
+    await getRooms(req, res, next);
+
+    expect(client.get).toHaveBeenCalledWith("rooms:page:1:limit:10");
+    expect(Room.find).toHaveBeenCalled();
+    expect(Room.populate).toHaveBeenCalledWith("hotel amenities");
+    expect(Room.skip).toHaveBeenCalledWith(0);
+    expect(Room.limit).toHaveBeenCalledWith(10);
+    expect(Room.exec).toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith({ status: 404, message: "There are no rooms available" });
+  });
+
+  it("should call next with an error if an exception occurs", async () => {
+    client.get.mockResolvedValue(null);
+    Room.exec.mockRejectedValue(new Error("Database error"));
+
+    const req = { query: { page: 1, limit: 10 } };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const next = jest.fn();
+
+    await getRooms(req, res, next);
+
+    expect(client.get).toHaveBeenCalledWith("rooms:page:1:limit:10");
+    expect(Room.find).toHaveBeenCalled();
+    expect(Room.populate).toHaveBeenCalledWith("hotel amenities");
+    expect(Room.skip).toHaveBeenCalledWith(0);
+    expect(Room.limit).toHaveBeenCalledWith(10);
+    expect(Room.exec).toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+    expect(res.status).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
- Integrated Redis caching to optimize response times by fetching room data from the cache when available.
- Implemented pagination handling in the `getRooms` controller using query parameters (`page`, `limit`).
- Added cache key generation for pagination, ensuring cached data is specific to page and limit combinations.
- Mocked Redis and pagination utilities in tests to simulate cache hits and MongoDB queries.
- Improved error handling and tests to cover scenarios such as database errors and no rooms found.
- Used `setEx` to store MongoDB query results in Redis with a TTL of 1 hour.